### PR TITLE
feat(platforms): add youtube platform adapter for subscriber tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,12 @@
 # THREADS_ACCESS_TOKEN=
 # THREADS_USER_ID=
 # THREADS_ACCESS_TOKEN_EXPIRES_AT_UTC=
+
+# YouTube
+# API key must have YouTube Data API v3 enabled
+# YOUTUBE_API_KEY=
+# Provide either a channel handle (e.g., @Google) OR a channel ID (e.g., UCK8sQmJBp8GCxrOtXWBpyEA)
+# If both are provided, YOUTUBE_CHANNEL_ID takes precedence.
+# YOUTUBE_HANDLE=
+# YOUTUBE_CHANNEL_ID=
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Feb-27, 2026 - 07:45 PM +08 - Added YouTube support to the CLI config command.
 - Feb-27, 2026 - 13:00 PM +08 - Added YouTube platform adapter to track channel subscriber counts using the YouTube Data API v3 and channel ID/handle configuration.
 - Feb-26, 2026 - 10:48 PM +08 - Added structured output flags (`--json`, `--csv`) to `track`, `show`, and `history`, with formatter helpers, CSV/JSON behavior tests, and updated README/config reference docs.
 - Feb-26, 2026 - 08:50 PM +08 - Disabled automatic GitHub Actions CI triggers by changing `CI` workflow to `workflow_dispatch` only (manual run).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Feb-27, 2026 - 13:00 PM +08 - Added YouTube platform adapter to track channel subscriber counts using the YouTube Data API v3 and channel ID/handle configuration.
 - Feb-26, 2026 - 10:48 PM +08 - Added structured output flags (`--json`, `--csv`) to `track`, `show`, and `history`, with formatter helpers, CSV/JSON behavior tests, and updated README/config reference docs.
 - Feb-26, 2026 - 08:50 PM +08 - Disabled automatic GitHub Actions CI triggers by changing `CI` workflow to `workflow_dispatch` only (manual run).
 - Feb-26, 2026 - 08:32 PM +08 - Updated quality workflow to keep CI non-mutating: added `lint-check` task (`ruff check` + `ruff format --check`), switched CI lint job to use it, and kept local autofix behavior in `lint`.

--- a/dev-docs/20260227-PLANS-youtube-adapter.md
+++ b/dev-docs/20260227-PLANS-youtube-adapter.md
@@ -1,0 +1,35 @@
+# PLANS: YouTube Subscriber Tracking
+
+Date: 2026-02-27
+Status: Proposed
+
+## Context
+
+Issue #6 requests tracking YouTube channel subscriber counts in sm-tracker.
+
+## Action Plan
+
+1. **Configuration (`.env` & `config.toml.example`)**
+    - Add `YOUTUBE_API_KEY` to `.env.example`.
+    - Add `YOUTUBE_HANDLE` and `YOUTUBE_CHANNEL_ID` to `.env.example` as mutually exclusive options.
+
+2. **Adapter Implementation (`src/sm_tracker/platforms/youtube.py`)**
+    - Create a new `YouTubeAdapter` class conforming to `PlatformAdapter`.
+    - Use `urllib.request` to query the YouTube Data API v3 (`https://www.googleapis.com/youtube/v3/channels`).
+    - Extract `subscriberCount` from the statistics block. Return `None` for `following_count`.
+
+3. **Adapter Registration (`src/sm_tracker/platforms/__init__.py`)**
+    - Import `create_youtube_adapter`.
+    - Add `"youtube"` to `SUPPORTED_PLATFORM_NAMES`.
+    - Add the factory to the `factories` dictionary in `resolve_adapters`.
+
+4. **Testing (`tests/platforms/test_youtube.py`)**
+    - Add unit tests verifying:
+        - Initialization with handle or channel ID.
+        - Validation error if neither or `API_KEY` is missing.
+        - Successful parsing of the API response (mocked `urlopen`).
+        - Safe handling of empty or error responses.
+
+5. **Verification**
+    - Run `pytest tests/platforms/test_youtube.py`.
+    - Ensure the linter (`ruff` / `mypy`) passes.

--- a/dev-docs/20260227-SPECS-youtube-adapter.md
+++ b/dev-docs/20260227-SPECS-youtube-adapter.md
@@ -1,0 +1,30 @@
+# SPECS: YouTube Subscriber Tracking
+
+Date: 2026-02-27
+Status: Proposed
+
+## Context
+
+Issue #6 requests tracking YouTube channel subscriber counts in sm-tracker.
+
+## Behavior
+
+- Add a new platform adapter `youtube` that conforms to `sm_tracker.platforms.PlatformAdapter`.
+- Configuration will be provided via environment variables:
+    - `YOUTUBE_API_KEY`: Required. The Google Cloud API key with YouTube Data API v3 enabled.
+    - `YOUTUBE_HANDLE`: Optional. The YouTube handle (e.g. `@channel`) to track.
+    - `YOUTUBE_CHANNEL_ID`: Optional. The YouTube channel ID to track.
+    - One of `YOUTUBE_HANDLE` or `YOUTUBE_CHANNEL_ID` must be provided. If both are provided, `YOUTUBE_CHANNEL_ID` takes precedence.
+- Data will be fetched using the YouTube Data API v3:
+    - Endpoint for handle: `https://www.googleapis.com/youtube/v3/channels?part=statistics&forHandle={handle}&key={api_key}`
+    - Endpoint for channel ID: `https://www.googleapis.com/youtube/v3/channels?part=statistics&id={channel_id}&key={api_key}`
+- The adapter will return a `PlatformCounts` object:
+    - `platform`: `"youtube"`
+    - `follower_count`: Parsed from `items[0].statistics.subscriberCount`
+    - `following_count`: `None` (YouTube does not expose subscription counts via this endpoint in a meaningful way for our use case).
+
+## Constraints
+
+- Standard library only (`urllib.request` and `json`), mirroring the implementation style of the `farcaster` adapter.
+- Handle missing responses, no items returned, and network timeouts gracefully using standard API patterns in the system.
+- Update `SUPPORTED_PLATFORM_NAMES` and factories in `src/sm_tracker/platforms/__init__.py`.

--- a/src/sm_tracker/cli/__init__.py
+++ b/src/sm_tracker/cli/__init__.py
@@ -27,7 +27,13 @@ from sm_tracker.config import (
     ConfigError,
     load_config,
 )
-from sm_tracker.db import fetch_history, fetch_latest, init_schema, insert_count, insert_snapshot
+from sm_tracker.db import (
+    fetch_history,
+    fetch_latest,
+    init_schema,
+    insert_count,
+    insert_snapshot,
+)
 from sm_tracker.db.connection import connect
 from sm_tracker.db.queries import CountRow
 from sm_tracker.logging import setup_logging
@@ -51,11 +57,22 @@ ENV_FIELD_SPECS: list[tuple[str, str, bool]] = [
     ("MASTODON_ACCESS_TOKEN", "Mastodon access token", True),
     ("MASTODON_INSTANCE", "Mastodon instance (for example mastodon.social)", True),
     ("THREADS_APP_ID", "Threads app ID (optional, needed for auth command)", False),
-    ("THREADS_APP_SECRET", "Threads app secret (optional, needed for auth command)", False),
+    (
+        "THREADS_APP_SECRET",
+        "Threads app secret (optional, needed for auth command)",
+        False,
+    ),
     ("THREADS_REDIRECT_URI", "Threads redirect URI", False),
     ("THREADS_ACCESS_TOKEN", "Threads access token", True),
     ("THREADS_USER_ID", "Threads user ID", True),
-    ("THREADS_ACCESS_TOKEN_EXPIRES_AT_UTC", "Threads token expiry UTC (ISO, optional)", False),
+    (
+        "THREADS_ACCESS_TOKEN_EXPIRES_AT_UTC",
+        "Threads token expiry UTC (ISO, optional)",
+        False,
+    ),
+    ("YOUTUBE_API_KEY", "YouTube API key", True),
+    ("YOUTUBE_CHANNEL_ID", "YouTube channel ID (optional if handle provided)", False),
+    ("YOUTUBE_HANDLE", "YouTube handle (optional if channel ID provided)", False),
 ]
 
 
@@ -547,7 +564,9 @@ def _history_follower_deltas(rows: list[CountRow]) -> list[str]:
     return deltas
 
 
-def _history_rows_with_deltas(rows: list[CountRow]) -> list[dict[str, str | int | None]]:
+def _history_rows_with_deltas(
+    rows: list[CountRow],
+) -> list[dict[str, str | int | None]]:
     deltas = _history_follower_deltas(rows)
     structured: list[dict[str, str | int | None]] = []
     for row, delta in zip(rows, deltas, strict=False):
@@ -731,7 +750,9 @@ def _run_config_wizard(config_path: Path) -> tuple[str, str, str, int, str]:
     return profile, db_path, logs_path, retention_int, normalized_level
 
 
-def _read_existing_profile_settings(config_path: Path) -> tuple[str, str, str, int, str]:
+def _read_existing_profile_settings(
+    config_path: Path,
+) -> tuple[str, str, str, int, str]:
     if not config_path.exists():
         return "dev", "", "", 0, ""
 
@@ -781,10 +802,19 @@ def _validate_required_env_values(env_values: Mapping[str, str]) -> list[str]:
         "farcaster": ["FARCASTER_API_KEY", "FARCASTER_USERNAME"],
         "mastodon": ["MASTODON_ACCESS_TOKEN", "MASTODON_INSTANCE"],
         "threads": ["THREADS_ACCESS_TOKEN", "THREADS_USER_ID"],
+        "youtube": ["YOUTUBE_API_KEY"],
     }
     warnings: list[str] = []
     for platform, keys in missing_by_platform.items():
         missing = [key for key in keys if not env_values.get(key, "").strip()]
+
+        if platform == "youtube":
+            if (
+                not env_values.get("YOUTUBE_CHANNEL_ID", "").strip()
+                and not env_values.get("YOUTUBE_HANDLE", "").strip()
+            ):
+                missing.append("YOUTUBE_CHANNEL_ID or YOUTUBE_HANDLE")
+
         if missing:
             warnings.append(f"{platform}: missing {', '.join(missing)}")
     return warnings

--- a/src/sm_tracker/platforms/__init__.py
+++ b/src/sm_tracker/platforms/__init__.py
@@ -55,6 +55,7 @@ def resolve_adapters(
     from sm_tracker.platforms.mastodon import create_mastodon_adapter
     from sm_tracker.platforms.threads import create_threads_adapter
     from sm_tracker.platforms.twitter import create_twitter_adapter
+    from sm_tracker.platforms.youtube import create_youtube_adapter
 
     env_map = os.environ if env is None else env
     factories: dict[str, Callable[[Mapping[str, str]], PlatformAdapter]] = {
@@ -63,6 +64,7 @@ def resolve_adapters(
         "mastodon": create_mastodon_adapter,
         "threads": create_threads_adapter,
         "twitter": create_twitter_adapter,
+        "youtube": create_youtube_adapter,
     }
     adapters: list[PlatformAdapter] = []
     warnings: list[str] = []

--- a/src/sm_tracker/platforms/__init__.py
+++ b/src/sm_tracker/platforms/__init__.py
@@ -43,6 +43,7 @@ SUPPORTED_PLATFORM_NAMES: tuple[str, ...] = (
     "mastodon",
     "threads",
     "twitter",
+    "youtube",
 )
 
 

--- a/src/sm_tracker/platforms/youtube.py
+++ b/src/sm_tracker/platforms/youtube.py
@@ -1,0 +1,96 @@
+"""YouTube platform adapter."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from sm_tracker.platforms import AdapterConfigError, PlatformCounts
+from sm_tracker.platforms.utils import extract_int
+
+
+@dataclass(frozen=True)
+class YouTubeAdapter:
+    """Fetch YouTube subscriber counts for a channel handle or ID."""
+
+    api_key: str
+    handle: str | None = None
+    channel_id: str | None = None
+    name: str = "youtube"
+
+    def __post_init__(self) -> None:
+        if not self.handle and not self.channel_id:
+            raise ValueError("YouTubeAdapter requires either a handle or a channel_id.")
+
+    def _build_url(self) -> str:
+        base_url = "https://www.googleapis.com/youtube/v3/channels?part=statistics&key="
+        api_key_encoded = quote(self.api_key, safe="")
+
+        if self.channel_id:
+            channel_id_encoded = quote(self.channel_id, safe="")
+            return f"{base_url}{api_key_encoded}&id={channel_id_encoded}"
+
+        if self.handle:
+            handle_encoded = quote(self.handle, safe="")
+            return f"{base_url}{api_key_encoded}&forHandle={handle_encoded}"
+
+        return ""
+
+    def _build_request(self) -> Request:
+        url = self._build_url()
+        return Request(
+            url,
+            headers={"User-Agent": "sm-tracker"},
+        )
+
+    def _request_channel_payload(self) -> Mapping[str, Any]:
+        request = self._build_request()
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        if isinstance(payload, Mapping):
+            return payload
+        return {}
+
+    def fetch_counts(self) -> PlatformCounts:
+        payload = self._request_channel_payload()
+        items = payload.get("items")
+
+        follower_count: int | None = None
+
+        if isinstance(items, list) and len(items) > 0:
+            first_item = items[0]
+            if isinstance(first_item, Mapping):
+                statistics = first_item.get("statistics")
+                if isinstance(statistics, Mapping):
+                    follower_count = extract_int(statistics, "subscriberCount")
+
+        return PlatformCounts(
+            platform=self.name,
+            follower_count=follower_count,
+            following_count=None,
+        )
+
+
+def create_youtube_adapter(env: Mapping[str, str]) -> YouTubeAdapter:
+    """Create a YouTube adapter from env vars."""
+    api_key = env.get("YOUTUBE_API_KEY", "").strip()
+    if not api_key:
+        raise AdapterConfigError("Skipping youtube: missing YOUTUBE_API_KEY in environment.")
+
+    channel_id = env.get("YOUTUBE_CHANNEL_ID", "").strip()
+    handle = env.get("YOUTUBE_HANDLE", "").strip()
+
+    if not channel_id and not handle:
+        raise AdapterConfigError(
+            "Skipping youtube: missing YOUTUBE_CHANNEL_ID or YOUTUBE_HANDLE in environment."
+        )
+
+    return YouTubeAdapter(
+        api_key=api_key,
+        channel_id=channel_id if channel_id else None,
+        handle=handle if handle else None,
+    )

--- a/tests/platforms/test_youtube.py
+++ b/tests/platforms/test_youtube.py
@@ -1,0 +1,151 @@
+"""Tests for the YouTube platform adapter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sm_tracker.platforms import AdapterConfigError, PlatformCounts
+from sm_tracker.platforms.youtube import YouTubeAdapter, create_youtube_adapter
+
+
+def test_create_youtube_adapter_with_handle() -> None:
+    env = {
+        "YOUTUBE_API_KEY": "test_key",
+        "YOUTUBE_HANDLE": "@test_channel",
+    }
+    adapter = create_youtube_adapter(env)
+    assert adapter.api_key == "test_key"
+    assert adapter.handle == "@test_channel"
+    assert adapter.channel_id is None
+    assert adapter.name == "youtube"
+
+
+def test_create_youtube_adapter_with_channel_id() -> None:
+    env = {
+        "YOUTUBE_API_KEY": "test_key",
+        "YOUTUBE_CHANNEL_ID": "UC_test_id",
+    }
+    adapter = create_youtube_adapter(env)
+    assert adapter.api_key == "test_key"
+    assert adapter.channel_id == "UC_test_id"
+    assert adapter.handle is None
+
+
+def test_create_youtube_adapter_missing_api_key() -> None:
+    env = {
+        "YOUTUBE_HANDLE": "@test_channel",
+    }
+    with pytest.raises(AdapterConfigError, match="missing YOUTUBE_API_KEY"):
+        create_youtube_adapter(env)
+
+
+def test_create_youtube_adapter_missing_handle_and_id() -> None:
+    env = {
+        "YOUTUBE_API_KEY": "test_key",
+    }
+    with pytest.raises(AdapterConfigError, match="missing YOUTUBE_CHANNEL_ID or YOUTUBE_HANDLE"):
+        create_youtube_adapter(env)
+
+
+def test_youtube_adapter_post_init_validation() -> None:
+    with pytest.raises(ValueError, match="requires either a handle or a channel_id"):
+        YouTubeAdapter(api_key="test_key")
+
+
+def _mock_response(payload: dict[str, Any]) -> Mock:
+    mock_resp = Mock()
+    mock_resp.read.return_value = json.dumps(payload).encode("utf-8")
+    mock_resp.__enter__ = Mock(return_value=mock_resp)
+    mock_resp.__exit__ = Mock(return_value=None)
+    return mock_resp
+
+
+@patch("sm_tracker.platforms.youtube.urlopen")
+def test_fetch_counts_success_with_handle(mock_urlopen: Mock) -> None:
+    mock_urlopen.return_value = _mock_response(
+        {"items": [{"statistics": {"subscriberCount": "12345"}}]}
+    )
+
+    adapter = YouTubeAdapter(api_key="test_key", handle="@test")
+    counts = adapter.fetch_counts()
+
+    assert counts == PlatformCounts(
+        platform="youtube",
+        follower_count=12345,
+        following_count=None,
+    )
+
+    # Verify the URL construction
+    request = mock_urlopen.call_args[0][0]
+    assert "forHandle=%40test" in request.full_url
+    assert "key=test_key" in request.full_url
+
+
+@patch("sm_tracker.platforms.youtube.urlopen")
+def test_fetch_counts_success_with_channel_id(mock_urlopen: Mock) -> None:
+    mock_urlopen.return_value = _mock_response(
+        {"items": [{"statistics": {"subscriberCount": "9876"}}]}
+    )
+
+    adapter = YouTubeAdapter(api_key="test_key", channel_id="UC123")
+    counts = adapter.fetch_counts()
+
+    assert counts == PlatformCounts(
+        platform="youtube",
+        follower_count=9876,
+        following_count=None,
+    )
+
+    # Verify the URL construction
+    request = mock_urlopen.call_args[0][0]
+    assert "id=UC123" in request.full_url
+    assert "key=test_key" in request.full_url
+
+
+@patch("sm_tracker.platforms.youtube.urlopen")
+def test_fetch_counts_empty_items(mock_urlopen: Mock) -> None:
+    mock_urlopen.return_value = _mock_response({"items": []})
+
+    adapter = YouTubeAdapter(api_key="test_key", handle="@test")
+    counts = adapter.fetch_counts()
+
+    assert counts == PlatformCounts(
+        platform="youtube",
+        follower_count=None,
+        following_count=None,
+    )
+
+
+@patch("sm_tracker.platforms.youtube.urlopen")
+def test_fetch_counts_missing_statistics(mock_urlopen: Mock) -> None:
+    mock_urlopen.return_value = _mock_response({"items": [{"id": "UC123"}]})
+
+    adapter = YouTubeAdapter(api_key="test_key", handle="@test")
+    counts = adapter.fetch_counts()
+
+    assert counts == PlatformCounts(
+        platform="youtube",
+        follower_count=None,
+        following_count=None,
+    )
+
+
+@patch("sm_tracker.platforms.youtube.urlopen")
+def test_fetch_counts_invalid_json(mock_urlopen: Mock) -> None:
+    mock_resp = Mock()
+    mock_resp.read.return_value = b"invalid json"
+    mock_resp.__enter__ = Mock(return_value=mock_resp)
+    mock_resp.__exit__ = Mock(return_value=None)
+    mock_urlopen.return_value = mock_resp
+
+    adapter = YouTubeAdapter(api_key="test_key", handle="@test")
+
+    # json.loads will raise json.JSONDecodeError, which is unhandled
+    # per constraints to let standard API failures bubble up unless we try-except it.
+    # The adapter doesn't wrap json.loads in try/except in the current impl.
+    with pytest.raises(json.JSONDecodeError):
+        adapter.fetch_counts()

--- a/tests/test_phase8_config_command.py
+++ b/tests/test_phase8_config_command.py
@@ -27,6 +27,9 @@ def _guided_input_for_full_setup() -> str:
                 "threads-token",
                 "12345",
                 "",
+                "youtube-key",
+                "UC12345",
+                "",
                 "dev",
                 "./data-dev.db",
                 "./logs-dev",
@@ -42,6 +45,9 @@ def _guided_input_with_empty_required_values() -> str:
     return (
         "\n".join(
             [
+                "",
+                "",
+                "",
                 "",
                 "",
                 "",
@@ -81,6 +87,8 @@ def test_config_command_guided_flow_creates_env_and_config() -> None:
     assert "TWITTER_BEARER_TOKEN=twitter-token" in env_contents
     assert "BLUESKY_HANDLE=alice.bsky.social" in env_contents
     assert "THREADS_ACCESS_TOKEN=threads-token" in env_contents
+    assert "YOUTUBE_API_KEY=youtube-key" in env_contents
+    assert "YOUTUBE_CHANNEL_ID=UC12345" in env_contents
     assert 'profile = "dev"' in config_contents
     assert 'db = "./data-dev.db"' in config_contents
     assert 'logs = "./logs-dev"' in config_contents
@@ -101,6 +109,7 @@ def test_config_command_shows_validation_warnings_for_missing_required_env_value
     assert "farcaster: missing FARCASTER_API_KEY, FARCASTER_USERNAME" in result.stdout
     assert "mastodon: missing MASTODON_ACCESS_TOKEN, MASTODON_INSTANCE" in result.stdout
     assert "threads: missing THREADS_ACCESS_TOKEN, THREADS_USER_ID" in result.stdout
+    assert "youtube: missing YOUTUBE_API_KEY, YOUTUBE_CHANNEL_ID or YOUTUBE_HANDLE" in result.stdout
     assert "TWITTER_BEARER_TOKEN=" not in env_contents
 
 


### PR DESCRIPTION
Resolves #6.

### Changes
- Added a `youtube` platform adapter implementing the `PlatformAdapter` protocol.
- Supported mapping via either `YOUTUBE_HANDLE` or `YOUTUBE_CHANNEL_ID` and `YOUTUBE_API_KEY`.
- Registered the adapter in `src/sm_tracker/platforms/__init__.py`.
- Added unit tests mimicking successful API responses, empty payloads, and validation edge cases.
- Includes `CHANGELOG.md` and `dev-docs`.